### PR TITLE
Theme toggler added

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,5 +1,7 @@
 import logo from './logo.svg';
 import './App.css';
+import ThemeProvider from './utils/ThemeContext';
+import ThemeButton from './components/ThemeButton/index';
 
 function App() {
   return (
@@ -18,6 +20,9 @@ function App() {
           Learn React
         </a>
       </header>
+      <ThemeProvider>
+        <ThemeButton />
+      </ThemeProvider>
     </div>
   );
 }

--- a/client/src/components/ThemeButton/index.js
+++ b/client/src/components/ThemeButton/index.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { useTheme } from '../../utils/ThemeContext';
+
+export default function ThemeButton() {
+
+  const { darkTheme, toggleTheme } = useTheme();
+
+  return (
+    <a href='/' onClick={toggleTheme} className='nav-link'>
+      Theme
+    </a>
+  );
+}

--- a/client/src/utils/ThemeContext.js
+++ b/client/src/utils/ThemeContext.js
@@ -1,0 +1,33 @@
+import React, { useState, useContext } from 'react';
+
+// Create our theme context using React.CreateContext()
+export const ThemeContext = React.createContext();
+
+// Create a custom hook that allows easy access to our ThemeContext values
+export const useTheme = () => useContext(ThemeContext);
+
+// Creating our theme provider. Accepts an argument of "props", here we plucking off the "children" object.
+// <ThemeProvider /> should wrap all affected elements
+export default function ThemeProvider({ children }) {
+  // Creating our state
+  const [darkTheme, setDarkTheme] = useState(true);
+
+  // Method to update our state
+  const toggleTheme = (e) => {
+    console.log(`darkTheme was ${darkTheme}`);
+    e.preventDefault();
+    return setDarkTheme((prev) => !prev);
+  };
+
+  // The provider component will wrap all other components inside of it that need access to our global state
+  return (
+    // Dark theme and toggle theme are getting provided to the child components
+    <ThemeContext.Provider value={{ darkTheme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+// ! To access the darkTheme boolean in a component:
+// ! -- import {useTheme} from '[relativePath]'
+// ! -- const { darkTheme, toggleTheme } = useTheme();


### PR DESCRIPTION
There are notes at the bottom of ThemeContext.js for the code necessary to apply the theme to components. 

In App.js 'ThemeProvider' must wrap all elements that require the dark/light theme.

in App.js 'ThemeButton' is currently placed at the bottom of the screen.  'ThemeButton' can be relocated to components.